### PR TITLE
feat: cross support for x86 and arm64 linux.

### DIFF
--- a/src/core.cc
+++ b/src/core.cc
@@ -827,7 +827,7 @@ int Coredump::ReadMeta(Lz4Stream& in)
         buf->Read((char*)&td._regs, sizeof(td._regs));
         buf->Read((char*)&td._fpregs, sizeof(td._fpregs));
         buf->Read((char*)&td._siginfo, sizeof(td._siginfo));
-        buf->Read((char*)&td._xstate, sizeof(td._xstate));
+        //buf->Read((char*)&td._xstate, sizeof(td._xstate));
 
         td._stat = in.GetFile();
         _process._threads.push_back(td);

--- a/src/core.cc
+++ b/src/core.cc
@@ -269,9 +269,8 @@ static inline int pt_call(pid_t pid, user_regs64_struct *oregs, uint64_t func, i
 #ifdef __aarch64__
     regs.regs[30] = 0;
 #else
-    regs.s_sp -= 8;
-    //uint64_t zero = 0;
-    rc = ptrace(PTRACE_POKEDATA, pid, regs.s_sp, 0);
+    regs.rsp -= 8;
+    rc = ptrace(PTRACE_POKEDATA, pid, regs.rsp, 0);
     assert(rc == 0);
 #endif
 

--- a/src/core.cc
+++ b/src/core.cc
@@ -24,9 +24,13 @@
 #include "core.h"
 #include "proc.h"
 
+// arthur only use a memory of BUFFER_SIZE on main stack.
+#define BUFFER_SIZE 1L*1024*1024         // general buffer size to store data
+#define ARTHUR_BUFFER_SIZE 2L*1024*1024  // take up 2M physical memory on stack
+
+static_assert(BUFFER_SIZE >= 1*1024*1024, "buffer size should more than 1MB.");
+
 #define roundup(x,n) (((x)+((n)-1))&(~((n)-1)))
-#define ARTHUR_BUFFER_SIZE 2*1024*1024  // take up 2M physical memory on stack
-#define BUFFER_SIZE 1*1024*1024         // general buffer size to store data
 
 extern "C" {
 
@@ -198,6 +202,7 @@ static inline int pt_detach(pid_t pid)
 static inline int pt_getregs(pid_t pid, user_regs64_struct *pregs)
 {
     int rc;
+
 #ifdef __aarch64__
     struct iovec iov;
     iov.iov_base = pregs;
@@ -205,6 +210,24 @@ static inline int pt_getregs(pid_t pid, user_regs64_struct *pregs)
     rc = ptrace(PTRACE_GETREGSET, pid, NT_PRSTATUS, &iov);
 #else
     rc = ptrace(PTRACE_GETREGS, pid, NULL, pregs);
+#endif
+
+    assert(rc == 0);
+    return rc;
+}
+
+// read all fp registers
+static inline int pt_getfpregs(pid_t pid, user_fpregs64_struct *pregs)
+{
+    int rc;
+
+#ifdef __aarch64__
+    struct iovec iov;
+    iov.iov_base = pregs;
+    iov.iov_len = sizeof(user_regs64_struct);
+    rc = ptrace(PTRACE_GETREGSET, pid, NT_FPREGSET, &iov);
+#else
+    rc = ptrace(PTRACE_GETFPREGS, pid, NULL, pregs);
 #endif
 
     assert(rc == 0);
@@ -253,26 +276,26 @@ static inline int pt_call(pid_t pid, user_regs64_struct *oregs, uint64_t func, i
 #endif
 
     // makeup function call and arguments
-    regs.s_pc = func;
+    regs.set_pc(func);
     for (int i=0; i<argc; i++) {
         switch (i) {
             case 0:
-                regs.s_ag0 = argv[0];
+                regs.set_arg0(argv[0]);
                 break;
             case 1:
-                regs.s_ag1 = argv[1];
+                regs.set_arg1(argv[1]);
                 break; 
             case 2:
-                regs.s_ag2 = argv[2];
+                regs.set_arg2(argv[2]);
                 break; 
             case 3:
-                regs.s_ag3 = argv[3];
+                regs.set_arg3(argv[3]);
                 break; 
             case 4:
-                regs.s_ag4 = argv[4];
+                regs.set_arg4(argv[4]);
                 break; 
             case 5:
-                regs.s_ag5 = argv[5];
+                regs.set_arg5(argv[5]);
                 break;
             default:
                assert(0); 
@@ -551,29 +574,52 @@ int Note::fill_file(const ProcessData& proc)
 // NT_PRSTATUS
 int Note::fill_prstatus(const ThreadData& thr)
 {
-    elf_prstatus64 *p = allocate<elf_prstatus64>();
-    p->pr_info.si_code = thr._siginfo.si_code;
-    p->pr_info.si_errno = thr._siginfo.si_errno;
-    p->pr_info.si_signo = thr._siginfo.si_signo;
-    p->pr_cursig = thr._siginfo.si_signo;
-    memcpy(&p->pr_reg, thr._regs, sizeof(p->pr_reg));
-    p->pr_pid = thr._d_stat->pid; 
-    p->pr_ppid = thr._d_stat->ppid; 
-    p->pr_pgrp = thr._d_stat->pgid; 
-    p->pr_sid = thr._d_stat->sid;
-    memcpy(&p->pr_utime, &thr._d_stat->utime, sizeof(p->pr_utime));
-    memcpy(&p->pr_stime, &thr._d_stat->stime, sizeof(p->pr_stime));
-    memcpy(&p->pr_cutime, &thr._d_stat->cutime, sizeof(p->pr_cutime));
-    memcpy(&p->pr_cstime, &thr._d_stat->cstime, sizeof(p->pr_cstime));
-    
+    if (thr._arch == ARCH_X64) {
+        x64_elf_prstatus *p = allocate<x64_elf_prstatus>();
+        p->pr_info.si_code = thr._siginfo.si_code;
+        p->pr_info.si_errno = thr._siginfo.si_errno;
+        p->pr_info.si_signo = thr._siginfo.si_signo;
+        p->pr_cursig = thr._siginfo.si_signo;
+        memcpy(&p->pr_reg, &thr._regs.x64, sizeof(thr._regs.x64));
+        p->pr_pid = thr._d_stat->pid; 
+        p->pr_ppid = thr._d_stat->ppid; 
+        p->pr_pgrp = thr._d_stat->pgid; 
+        p->pr_sid = thr._d_stat->sid;
+        memcpy(&p->pr_utime, &thr._d_stat->utime, sizeof(p->pr_utime));
+        memcpy(&p->pr_stime, &thr._d_stat->stime, sizeof(p->pr_stime));
+        memcpy(&p->pr_cutime, &thr._d_stat->cutime, sizeof(p->pr_cutime));
+        memcpy(&p->pr_cstime, &thr._d_stat->cstime, sizeof(p->pr_cstime));
+    }
+    else if (thr._arch == ARCH_AARCH64) {
+        arm64_elf_prstatus *p = allocate<arm64_elf_prstatus>();
+        p->pr_info.si_code = thr._siginfo.si_code;
+        p->pr_info.si_errno = thr._siginfo.si_errno;
+        p->pr_info.si_signo = thr._siginfo.si_signo;
+        p->pr_cursig = thr._siginfo.si_signo;
+        memcpy(&p->pr_reg, &thr._regs.arm64, sizeof(thr._regs.arm64));
+        p->pr_pid = thr._d_stat->pid; 
+        p->pr_ppid = thr._d_stat->ppid; 
+        p->pr_pgrp = thr._d_stat->pgid; 
+        p->pr_sid = thr._d_stat->sid;
+        memcpy(&p->pr_utime, &thr._d_stat->utime, sizeof(p->pr_utime));
+        memcpy(&p->pr_stime, &thr._d_stat->stime, sizeof(p->pr_stime));
+        memcpy(&p->pr_cutime, &thr._d_stat->cutime, sizeof(p->pr_cutime));
+        memcpy(&p->pr_cstime, &thr._d_stat->cstime, sizeof(p->pr_cstime));
+    }
     return 0;
 }
 
 // NT_FPREGSET
 int Note::fill_fpregset(const ThreadData& thr)
 {
-    elf_fpregset64_t *p = allocate<elf_fpregset64_t>();
-    memcpy(p, &thr._fpregs, sizeof(*p));
+    if (thr._arch == ARCH_X64) {
+        x64_elf_fpregset *p = allocate<x64_elf_fpregset>();
+        memcpy(p, &thr._fpregs.x64, sizeof(thr._fpregs.x64));
+    }
+    else if (thr._arch == ARCH_AARCH64) {
+        arm64_elf_fpregset *p = allocate<arm64_elf_fpregset>();
+        memcpy(p, &thr._fpregs.arm64, sizeof(thr._fpregs.arm64));
+    }
     return 0;
 }
 
@@ -585,7 +631,7 @@ int Note::fill_siginfo(const ThreadData& thr)
     return 0;
 }
 
-#ifdef __x86_64__
+#if 0
 // NT_X86_XSTATE
 int Note::fill_x86_xstate(const ThreadData& thr)
 {
@@ -593,9 +639,7 @@ int Note::fill_x86_xstate(const ThreadData& thr)
     memcpy(p, &thr._xstatereg, 2688);
     return 0;
 }
-#endif
 
-#ifdef __aarch64__
 // NT_SVE
 int Note::fill_arm_sve(const ThreadData& thr)
 {
@@ -696,12 +740,7 @@ int Coredump::WriteThreadMeta(Lz4Stream& out, pid_t pid, bool is_main) {
     out.Write(buf, sizeof(i._regs));
 
     // get FP Registers 
-#ifdef __aarch64__
-    // TBD: ARM64 uses r14 for link register
-    //rc = ptrace(PTRACE_GETFPREGSET, pid, 0, buf);
-#else
-    rc = ptrace(PTRACE_GETFPREGS, pid, 0, buf);
-#endif
+    rc = pt_getfpregs(pid, (user_fpregs64_struct*)buf);
     assert(rc == 0);
     out.Write(buf, sizeof(i._fpregs));
 
@@ -710,7 +749,7 @@ int Coredump::WriteThreadMeta(Lz4Stream& out, pid_t pid, bool is_main) {
     assert(rc == 0);
     out.Write(buf, sizeof(i._siginfo));
 
-#ifdef __x86_64__
+#if 0
     // get NT_X86_XSTATE     
     struct iovec iovec = { buf, sizeof(i._xstatereg) };
     rc = ptrace(PTRACE_GETREGSET, pid, NT_X86_XSTATE, &iovec);
@@ -736,11 +775,14 @@ int Coredump::VerifyFileHeader(Lz4Stream& in)
         return -1;
     }
 
-    rc = in.ReadRaw((char*)&hdr.version, sizeof(hdr.version));
-    if (rc != sizeof(hdr.version) || hdr.version != 1) {
-        error("we don't support the arthur version.");
+    rc = in.ReadRaw((char*)&hdr.m, sizeof(hdr.m));
+    if (rc != sizeof(hdr.m) || hdr.m.version > ACORE_VERSION) {
+        error("acore version %d > %d.", hdr.m.version, ACORE_VERSION);
         return -1;
     }
+
+    // for version 1, the arch is always x64.
+    _arch = hdr.m.arch;
 
     return 0;
 }
@@ -778,6 +820,7 @@ int Coredump::ReadMeta(Lz4Stream& in)
    
     for (int i=0; i<thread_num; i++) {
         ThreadData td;
+        td._arch = _arch; 
         
         buf = in.ReadBlock(hdr);
         
@@ -785,10 +828,7 @@ int Coredump::ReadMeta(Lz4Stream& in)
         buf->Read((char*)&td._regs, sizeof(td._regs));
         buf->Read((char*)&td._fpregs, sizeof(td._fpregs));
         buf->Read((char*)&td._siginfo, sizeof(td._siginfo));
-
-#ifdef __x86_64__
-        buf->Read((char*)&td._xstatereg, sizeof(td._xstatereg));
-#endif
+        buf->Read((char*)&td._xstate, sizeof(td._xstate));
 
         td._stat = in.GetFile();
         _process._threads.push_back(td);
@@ -893,6 +933,8 @@ int Coredump::WriteElfHeader(Lz4Stream& out)
 {
     Elf64_Ehdr ehdr;
     ehdr.e_phnum = _phdrs.size();
+
+    // hard coded the 'machine' by platform
 #ifdef __aarch64__
     ehdr.e_machine = EM_AARCH64; 
 #else
@@ -1039,12 +1081,12 @@ int Coredump::GenerateNotes()
         nt->fill_prstatus(i);
         _notes.push_back(nt);
 
-#ifdef __x86_64__
         // NT_FPREGSET (floating point registers)
         nt = new Note(NT_FPREGSET);
         nt->fill_fpregset(i);
         _notes.push_back(nt);
         
+#if 0
         // NT_X86_XSTATE (x86 XSAVE extended state)
         nt = new Note(NT_X86_XSTATE);
         nt->fill_x86_xstate(i);
@@ -1222,8 +1264,8 @@ int Coredump::forkcore(const char *corefile, bool sys_core)
         //uint64_t gv[6] = {0, 0x1000, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANONYMOUS|MAP_PRIVATE, 0, 0};
         uint64_t gv[6] = {0, 0x1000, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANONYMOUS|MAP_PRIVATE, 0, 0};
         pt_call(_pid, &regs, r_mmap, 6, gv);
-        info("mmap = %lx", regs.s_rc);
-        inject_page = regs.s_rc;
+        info("mmap = %lx", regs.get_rc());
+        inject_page = regs.get_rc();
     }
     pt_getregs(_pid, &regs);
 
@@ -1242,15 +1284,15 @@ int Coredump::forkcore(const char *corefile, bool sys_core)
      
         pt_write(_pid, inject_page, (void *)inject_fork, inject_size);
         pt_call(_pid, &regs, inject_page, 0, NULL);
-        info("child_pid = %d", (int)regs.s_rc);
-        _core_pid = regs.s_rc;
+        info("child_pid = %d", (int)regs.get_rc());
+        _core_pid = regs.get_rc();
     }
 
     // munmap injected page.
     {
         uint64_t gv[2] = {inject_page, 0x1000};
         pt_call(_pid, &regs, r_munmap, 2, gv);
-        info("munmap = %d", (int)regs.s_rc);
+        info("munmap = %d", (int)regs.get_rc());
     }
 
     // restore program 
@@ -1280,7 +1322,7 @@ int Coredump::forkcore(const char *corefile, bool sys_core)
     {
         uint64_t gv[3] = { (uint64_t)_core_pid, (uint64_t)NULL, 0 };
         pt_call(_pid, &regs, r_waitpid, 3, gv);
-        info("waitpid = %d", (int)regs.s_rc);
+        info("waitpid = %d", (int)regs.get_rc());
     }
     pt_setregs(_pid, &saved_regs);
     pt_detach(_pid);
@@ -1377,8 +1419,8 @@ int Coredump::forkcore_m(const char *corefile, bool sys_core)
     {
         uint64_t gv[6] = {0, 0x1000, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANONYMOUS|MAP_PRIVATE, 0, 0};
         pt_call(_pid, &regs, r_mmap, 6, gv);
-        info("mmap = %lx", regs.s_rc);
-        inject_page = regs.s_rc;
+        info("mmap = %lx", regs.get_rc());
+        inject_page = regs.get_rc();
     }
     pt_getregs(_pid, &regs);
 
@@ -1397,15 +1439,15 @@ int Coredump::forkcore_m(const char *corefile, bool sys_core)
      
         pt_write(_pid, inject_page, (void *)inject_fork, inject_size);
         pt_call(_pid, &regs, inject_page, 0, NULL);
-        info("child_pid = %d", (int)regs.s_rc);
-        _core_pid = regs.s_rc;
+        info("child_pid = %d", (int)regs.get_rc());
+        _core_pid = regs.get_rc();
     }
 
     // munmap injected page.
     {
         uint64_t gv[2] = {inject_page, 0x1000};
         pt_call(_pid, &regs, r_munmap, 2, gv);
-        info("munmap = %d", (int)regs.s_rc);
+        info("munmap = %d", (int)regs.get_rc());
     }
 
     // restore program regs
@@ -1465,7 +1507,7 @@ int Coredump::forkcore_m(const char *corefile, bool sys_core)
     {
         uint64_t gv[3] = {(uint64_t)_core_pid, (uint64_t)NULL, 0};
         pt_call(_pid, &regs, r_waitpid, 3, gv);
-        info("waitpid = %d", (int)regs.s_rc);
+        info("waitpid = %d", (int)regs.get_rc());
     }
     pt_setregs(_pid, &saved_regs);
     if(!WIFSTOPPED(s)) {
@@ -1616,10 +1658,16 @@ int Coredump::decompress(const char* in_file, const char* out_core)
     if (rc < 0) {
         return -1;
     }
-    VerifyFileHeader(in);
+    rc = VerifyFileHeader(in);
+    if (rc != 0) {
+        return rc;
+    }
 
     // load meta
-    ReadMeta(in);
+    rc = ReadMeta(in);
+    if (rc != 0) {
+        return rc;
+    }
     
     char fpath[PATH_MAX];
     if (!out_core) {

--- a/src/core.cc
+++ b/src/core.cc
@@ -224,7 +224,7 @@ static inline int pt_getfpregs(pid_t pid, user_fpregs64_struct *pregs)
 #ifdef __aarch64__
     struct iovec iov;
     iov.iov_base = pregs;
-    iov.iov_len = sizeof(user_regs64_struct);
+    iov.iov_len = sizeof(user_fpregs64_struct);
     rc = ptrace(PTRACE_GETREGSET, pid, NT_FPREGSET, &iov);
 #else
     rc = ptrace(PTRACE_GETFPREGS, pid, NULL, pregs);

--- a/src/elf.h
+++ b/src/elf.h
@@ -167,31 +167,38 @@ struct Elf64_Ehdr {
 /* Core specifications */
 /* Unsigned 64-bit integer aligned to 8 bytes.  */
 //typedef uint64_t __attribute__ ((__aligned__ (8))) a8_uint64_t;
-typedef uint64_t a8_uint64_t;
-typedef a8_uint64_t elf_greg64_t;
+typedef uint64_t elf_greg64_t;
 
-#ifdef __aarch64__
-
-struct user_regs64_struct
+// general purpose registers for arm64
+struct arm64_user_regs64_struct
 {
-  uint64_t regs[31];
-  uint64_t sp;
-  uint64_t pc;
-  uint64_t pstate;
+    uint64_t regs[31];
+    uint64_t sp;
+    uint64_t pc;
+    uint64_t pstate;
 
-#define s_pc    pc 
-#define s_sp    sp 
-#define s_fp    regs[29] 
-#define s_rc    regs[0]
+    inline uint64_t get_pc() { return pc; }
+    inline uint64_t get_sp() { return sp; }
+    inline uint64_t get_rc() { return regs[0]; }
+#if 0
+    inline uint64_t get_arg0() { return regs[0]; }
+    inline uint64_t get_arg1() { return regs[1]; }
+    inline uint64_t get_arg2() { return regs[2]; }
+    inline uint64_t get_arg3() { return regs[3]; }
+    inline uint64_t get_arg4() { return regs[4]; }
+    inline uint64_t get_arg5() { return regs[5]; }
+#endif
 
-#define s_ag0   regs[0]
-#define s_ag1   regs[1]
-#define s_ag2   regs[2]
-#define s_ag3   regs[3]
-#define s_ag4   regs[4]
-#define s_ag5   regs[5]
+    inline void set_pc(uint64_t v) { pc = v; }
+    inline void set_sp(uint64_t v) { sp = v; }
+    inline uint64_t set_arg0(uint64_t v) { return regs[0] = v; }
+    inline uint64_t set_arg1(uint64_t v) { return regs[1] = v; }
+    inline uint64_t set_arg2(uint64_t v) { return regs[2] = v; }
+    inline uint64_t set_arg3(uint64_t v) { return regs[3] = v; }
+    inline uint64_t set_arg4(uint64_t v) { return regs[4] = v; }
+    inline uint64_t set_arg5(uint64_t v) { return regs[5] = v; }
 
-    static void DebugPrint(user_regs64_struct *r) {
+    static void DebugPrint(arm64_user_regs64_struct *r) {
         for (int i=0; i<31; i++) 
             printf("x%d = %lx (%lu)\n", i, r->regs[i], r->regs[i]);
         printf("pc = %lx\n", r->pc);
@@ -199,77 +206,80 @@ struct user_regs64_struct
     }
 };
 
-struct user_fpsimd64_struct
+// fp and simd register for arm64
+struct arm64_user_fpsimd64_struct
 {
   __uint128_t  vregs[32];
   unsigned int fpsr;
   unsigned int fpcr;
 };
 
+static_assert(sizeof(arm64_user_fpsimd64_struct)==528, "invalid prstatus");
+
+typedef arm64_user_fpsimd64_struct arm64_elf_fpregset;
+
+#if 0
 #define ELF_NGREG64 (sizeof (struct user_regs64_struct) / sizeof(elf_greg64_t))
 typedef elf_greg64_t elf_gregset64_t[ELF_NGREG64];
-typedef user_fpsimd64_struct elf_fpregset64_t;
 typedef elf_prpsinfo elf_prpsinfo64;
 typedef elf_prstatus elf_prstatus64;
+#endif
 
-static_assert(sizeof(elf_prstatus64)==0x188, "invalid prstatus");
-static_assert(sizeof(elf_prpsinfo64)==0x88, "invalid prpsinfo");
-static_assert(sizeof(siginfo_t)==0x80, "invalid prpsinfo");
 
-#else 
-#define ELF_PRARGSZ     (80)    /* Number of chars for args.  */
-
-/* Signal info.  */
-struct elf_siginfo
-  {
-    int si_signo;			/* Signal number.  */
-    int si_code;			/* Extra code.  */
-    int si_errno;			/* Errno.  */
-  };
-
-struct user_regs64_struct
+// genenal purpose registers for x64
+struct x64_user_regs64_struct
 {
-    a8_uint64_t r15;
-    a8_uint64_t r14;
-    a8_uint64_t r13;
-    a8_uint64_t r12;
-    a8_uint64_t rbp;
-    a8_uint64_t rbx;
-    a8_uint64_t r11;
-    a8_uint64_t r10;
-    a8_uint64_t r9;
-    a8_uint64_t r8;
-    a8_uint64_t rax;
-    a8_uint64_t rcx;
-    a8_uint64_t rdx;
-    a8_uint64_t rsi;
-    a8_uint64_t rdi;
-    a8_uint64_t orig_rax;
-    a8_uint64_t rip;
-    a8_uint64_t cs;
-    a8_uint64_t eflags;
-    a8_uint64_t rsp;
-    a8_uint64_t ss;
-    a8_uint64_t fs_base;
-    a8_uint64_t gs_base;
-    a8_uint64_t ds;
-    a8_uint64_t es;
-    a8_uint64_t fs;
-    a8_uint64_t gs;
+    uint64_t r15;
+    uint64_t r14;
+    uint64_t r13;
+    uint64_t r12;
+    uint64_t rbp;
+    uint64_t rbx;
+    uint64_t r11;
+    uint64_t r10;
+    uint64_t r9;
+    uint64_t r8;
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t orig_rax;
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t eflags;
+    uint64_t rsp;
+    uint64_t ss;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint64_t ds;
+    uint64_t es;
+    uint64_t fs;
+    uint64_t gs;
 
-#define s_pc    rip
-#define s_sp    rsp
-#define s_fp    rbp
-#define s_rc    rax
+    inline uint64_t get_pc() { return rip; }
+    inline uint64_t get_sp() { return rsp; }
+    inline uint64_t get_rc() { return rax; }
+#if 0
+    inline uint64_t get_arg0(int i) { return rdi; }
+    inline uint64_t get_arg1(int i) { return rsi; }
+    inline uint64_t get_arg2(int i) { return rdx; }
+    inline uint64_t get_arg3(int i) { return rcx; }
+    inline uint64_t get_arg4(int i) { return r8; }
+    inline uint64_t get_arg5(int i) { return r9; }
+#endif
 
-#define s_ag0   rdi
-#define s_ag1   rsi
-#define s_ag2   rdx
-#define s_ag3   rcx
-#define s_ag4   r8
-#define s_ag5   r9
+    inline void set_pc(uint64_t v) { rip = v; }
+    inline void set_sp(uint64_t v) { rsp = v; }
+    //inline void set_rc(uint64_t v) { rax = v; }
+    inline uint64_t set_arg0(uint64_t v) { return rdi = v; }
+    inline uint64_t set_arg1(uint64_t v) { return rsi = v; }
+    inline uint64_t set_arg2(uint64_t v) { return rdx = v; }
+    inline uint64_t set_arg3(uint64_t v) { return rcx = v; }
+    inline uint64_t set_arg4(uint64_t v) { return r8 = v; }
+    inline uint64_t set_arg5(uint64_t v) { return r9 = v; }
 
-    static void DebugPrint(user_regs64_struct *r) {
+    static void DebugPrint(x64_user_regs64_struct *r) {
         printf("RIP %16lx FLG %16lx\n", r->rip, r->eflags);
         printf("RSP %16lx RBP %16lx\n", r->rsp, r->rbp);
         printf("RAX %16lx RBX %16lx\n", r->rax, r->rbx);
@@ -286,7 +296,8 @@ struct user_regs64_struct
     }
 };
 
-struct user_fpregs64_struct
+// fp registers for x64 
+struct x64_user_fpregs64_struct
 {
   unsigned short int	cwd;
   unsigned short int	swd;
@@ -300,29 +311,44 @@ struct user_fpregs64_struct
   unsigned int		xmm_space[64];  /* 16*16 bytes for each XMM-reg = 256 bytes */
   unsigned int		padding[24];
 };
+static_assert(sizeof(x64_user_fpregs64_struct)==0x200, "invalid prstatus");
 
-static_assert(sizeof(user_fpregs64_struct)==0x200, "invalid prstatus");
+typedef x64_user_fpregs64_struct x64_elf_fpregset;
 
-#define ELF_NGREG64 (sizeof (struct user_regs64_struct) / sizeof(elf_greg64_t))
-typedef elf_greg64_t elf_gregset64_t[ELF_NGREG64];
+// gregset for x64
+#define X64_NGREG64 (sizeof (struct x64_user_regs64_struct) / sizeof(elf_greg64_t))
+typedef elf_greg64_t x64_gregset64_t[X64_NGREG64];
 
-typedef user_fpregs64_struct elf_fpregset64_t;
+// gregset for arm64
+#define ARM64_NGREG64 (sizeof (struct arm64_user_regs64_struct) / sizeof(elf_greg64_t))
+typedef elf_greg64_t arm64_gregset64_t[ARM64_NGREG64];
 
+// x64 xstate 
 #define X86_XSTATE_MAX_SIZE 2696
-typedef char elf_x86xstatereg[X86_XSTATE_MAX_SIZE];
+typedef char x64_xstatereg[X86_XSTATE_MAX_SIZE];
 
-struct prstatus64_timeval
+// signal info struct used in prstatus
+struct elf_siginfo64
 {
-    a8_uint64_t tv_sec;
-    a8_uint64_t tv_usec;
+    int si_signo;			/* Signal number.  */
+    int si_code;			/* Extra code.  */
+    int si_errno;			/* Errno.  */
 };
 
-struct elf_prstatus64
+// timeval struct used in prstatus
+struct prstatus64_timeval
 {
-    struct elf_siginfo pr_info;	/* Info associated with signal.  */
+    uint64_t tv_sec;
+    uint64_t tv_usec;
+};
+
+// prstatus for arm64
+struct arm64_elf_prstatus
+{
+    struct elf_siginfo64 pr_info;	/* Info associated with signal.  */
     short int pr_cursig;		/* Current signal.  */
-    a8_uint64_t pr_sigpend;		/* Set of pending signals.  */
-    a8_uint64_t pr_sighold;		/* Set of held signals.  */
+    uint64_t pr_sigpend;		/* Set of pending signals.  */
+    uint64_t pr_sighold;		/* Set of held signals.  */
     pid_t pr_pid;
     pid_t pr_ppid;
     pid_t pr_pgrp;
@@ -331,31 +357,63 @@ struct elf_prstatus64
     struct prstatus64_timeval pr_stime;		/* System time.  */
     struct prstatus64_timeval pr_cutime;	/* Cumulative user time.  */
     struct prstatus64_timeval pr_cstime;	/* Cumulative system time.  */
-    elf_gregset64_t pr_reg;		/* GP registers.  */
+    arm64_gregset64_t pr_reg;		/* GP registers.  */
     int pr_fpvalid;			/* True if math copro being used.  */
 };
 
-static_assert(sizeof(elf_prstatus64)==0x150, "invalid prstatus");
+static_assert(sizeof(arm64_elf_prstatus)==0x188, "invalid prstatus");
 
+// prstatus for x64
+struct x64_elf_prstatus
+{
+    struct elf_siginfo64 pr_info;	/* Info associated with signal.  */
+    short int pr_cursig;		/* Current signal.  */
+    uint64_t pr_sigpend;		/* Set of pending signals.  */
+    uint64_t pr_sighold;		/* Set of held signals.  */
+    pid_t pr_pid;
+    pid_t pr_ppid;
+    pid_t pr_pgrp;
+    pid_t pr_sid;
+    struct prstatus64_timeval pr_utime;		/* User time.  */
+    struct prstatus64_timeval pr_stime;		/* System time.  */
+    struct prstatus64_timeval pr_cutime;	/* Cumulative user time.  */
+    struct prstatus64_timeval pr_cstime;	/* Cumulative system time.  */
+    x64_gregset64_t pr_reg;		/* GP registers.  */
+    int pr_fpvalid;			/* True if math copro being used.  */
+};
+
+static_assert(sizeof(x64_elf_prstatus)==0x150, "invalid prstatus");
+
+// prpsinfo
 struct elf_prpsinfo64
 {
     char pr_state;			/* Numeric process state.  */
     char pr_sname;			/* Char for pr_state.  */
     char pr_zomb;			/* Zombie.  */
     char pr_nice;			/* Nice val.  */
-    a8_uint64_t pr_flag;	/* Flags.  */
+    uint64_t pr_flag;	/* Flags.  */
     unsigned int pr_uid;
     unsigned int pr_gid;
     int pr_pid, pr_ppid, pr_pgrp, pr_sid;
     char pr_fname[16];			/* Filename of executable.  */
+#define ELF_PRARGSZ     (80)    /* Number of chars for args.  */
     char pr_psargs[ELF_PRARGSZ];	/* Initial part of arg list.  */
 };
 
 static_assert(sizeof(elf_prpsinfo64)==0x88, "invalid prpsinfo");
 
-// defined in signal.h
+// siginfo_t
 static_assert(sizeof(siginfo_t)==0x80, "invalid prpsinfo");
 
-#endif // x86_64
+#ifdef __aarch64__
+typedef arm64_user_regs64_struct    user_regs64_struct;
+typedef arm64_user_fpsimd64_struct  user_fpregs64_struct;
+
+#elif __x86_64__
+typedef x64_user_regs64_struct      user_regs64_struct;
+typedef x64_user_fpregs64_struct    user_fpregs64_struct;
+
+#endif
+
 
 #endif // _ARTHUR_ELF_H_


### PR DESCRIPTION
The patch supports the decompress on x64 Linux for an arm64 acorefile or on arm64 for x64 acorefile.
acorefile header changed for the aarch64 platform, so version number now increased to 2.
the new version 2 arthur can decompress the old version x86 acorefile.

